### PR TITLE
Add header & subtext for river sensor data

### DIFF
--- a/usgs-details.html
+++ b/usgs-details.html
@@ -10,24 +10,40 @@
             width: 700px;
             height: 700px;
             background-color: #000000;
-            margin-top: 250px;
-            margin-left: 200px;
+            margin-top: 245px;
+            margin-left: 205px;
             color: #ffffff;
         }
 
+        #sensor-data {
+            margin-top: 15px;
+            margin-bottom: 15px;
+            margin-left: 10px;
+        }
+
         #value {
-            font-size: 36px;
+            font-size: 48px;
         }
 
         #units {
+            font-size: 36px;
+        }
+
+        #header,
+        #subtext {
             font-size: 24px;
+            width: 250px;
         }
     </style>
 </head>
 <body>
     <div class="container">
-        <span id="value"></span>
-        <span id="units"></span>
+        <div id="header"></div>
+        <div id="sensor-data">
+            <span id="value"></span>
+            <span id="units"></span>
+        </div>
+        <div id="subtext"></div>
     </div>
     <script type="text/javascript">
         // String constants
@@ -48,7 +64,8 @@
                 },
                 fallback: [
                     42, 32, 42, 51, 61, 71, 80, 90, 80, 71, 61, 51
-                ]
+                ],
+                display: 'temperature',
             },
             ph: {
                 code: '00400',
@@ -57,6 +74,7 @@
                 fallback: [
                     5.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 7.5, 7, 6.5, 6
                 ],
+                display: 'pH',
             },
             dissolvedOxygen: {
                 code: '00300',
@@ -64,7 +82,8 @@
                 transform: function(dO) { return dO; }, // Identity
                 fallback: [
                     10, 12, 10, 8, 6, 4, 2, 1, 2, 4, 6, 8
-                ]
+                ],
+                display: 'oxygen',
             },
             salinity: {
                 code: '00095',
@@ -76,6 +95,7 @@
                 fallback: [
                     848, 1000, 848, 697, 545, 393, 242, 90, 242, 393, 545, 697
                 ],
+                display: 'salinity',
             },
             turbidity: {
                 code: '63680',
@@ -87,8 +107,9 @@
                 },
                 fallback: [
                     VERY_LOW, VERY_LOW, LOW, LOW, MODERATE, MODERATE, HIGH, VERY_HIGH, HIGH, HIGH, MODERATE, LOW
-                ]
-            }
+                ],
+                display: 'turbidity',
+            },
         };
 
         // Hat tip https://stackoverflow.com/a/901144/6995854
@@ -125,6 +146,7 @@
             return function() {
                 var value = metric.fallback[new Date().getMonth()];
                 var units = metric.units;
+                var isFallback = true;
 
                 if (this.status === 200) {
                     var json = JSON.parse(this.responseText);
@@ -135,6 +157,7 @@
                         console.log('From API: ' + apiValue + ' ' + apiUnits);
 
                         value = metric.transform(apiValue);
+                        isFallback = false;
                     } catch (ex) {
                         console.warn('Error while parsing result: ' + ex.message);
                     }
@@ -143,9 +166,29 @@
                     console.log('Using fallback values');
                 }
 
-                document.getElementById('value').innerText = value;
-                document.getElementById('units').innerText = units;
+                return renderData(value, units, metric, isFallback);
             };
+        }
+
+        // Create header text for live and fallback values
+        function renderHeader(metric, isFallback) {
+            var firstWord = isFallback ? 'Typical ' : 'Current ';
+            return firstWord + metric.display + ' in the Schuylkill River:';
+        }
+
+        // Create subtext for live and fallback values
+        function renderSubtext(isFallback) {
+            return isFallback ?
+                'A common sensor reading for this month.' :
+                'This reading comes from a nearby sensor.';
+        }
+
+        // Write live or fallback values to the document
+        function renderData(value, units, metric, isFallback) {
+            document.getElementById('value').innerText = value;
+            document.getElementById('units').innerText = units;
+            document.getElementById('header').innerText = renderHeader(metric, isFallback);
+            document.getElementById('subtext').innerText = renderSubtext(isFallback);
         }
 
         // Function to fetch values from USGS given a metric


### PR DESCRIPTION
## Overview

This PR adjusts the styling of the data from the live API & fallback values in a few ways. The changes here:

- add a header to note that the value represents a reading from the Schuylkill river for whatever metric
- add a subscript to note that the reading's either from a nearby river sensor or that it represents a typical value for this month
- add some css style rules to center the data block & format the text a bit
- move the calls to write data to the document into a separate function, and create `renderHeader` and `renderSubtext` functions which create that text depending on whether the data represents a live or fallback value.

Connects #12 

## Screenshots

<details>

<summary>
Live readings from the API:
</summary>

![temperature](https://user-images.githubusercontent.com/4165523/27601641-03ba6ece-5b3e-11e7-90c8-622fe01aea7c.png)
![ph](https://user-images.githubusercontent.com/4165523/27601638-03a575d2-5b3e-11e7-9d72-a9a3b2fb29da.png)
![salinity](https://user-images.githubusercontent.com/4165523/27601637-03a54c9c-5b3e-11e7-84dc-433252d82371.png)
![turbidity](https://user-images.githubusercontent.com/4165523/27601640-03ad7494-5b3e-11e7-9c2f-e1d51704abee.png)
![oxygen](https://user-images.githubusercontent.com/4165523/27601639-03ab6848-5b3e-11e7-8482-09b72c50175c.png)

</details>
<details>

<summary>
Fallback values:
</summary>

![fallbackph](https://user-images.githubusercontent.com/4165523/27601653-0d03d38a-5b3e-11e7-8167-f1111a7d146b.png)
![fallbacksalinity](https://user-images.githubusercontent.com/4165523/27601650-0d00e2f6-5b3e-11e7-9f63-9713cc0a3eb9.png)
![fallbacktemperature](https://user-images.githubusercontent.com/4165523/27601651-0d014e80-5b3e-11e7-8160-be91012ee8a5.png)
![fallbackturbidity](https://user-images.githubusercontent.com/4165523/27601654-0d0528ac-5b3e-11e7-944e-dad23a357d1a.png)
![fallbackoxygen](https://user-images.githubusercontent.com/4165523/27601652-0d02977c-5b3e-11e7-93b2-3004aa96d7ae.png)

</details>

## Notes

I punted on making changes to the font or to the text color, as @ajrobbins mentioned in the comments on #12 that we'll likely have a designer take a look at this during the next sprint.

Happy to adjust the copy, here, too -- I tried to aim for succinct in order to make it fit in the circle.

## Testing

* get this branch, then `server` and visit `localhost:9000`
* check all the spokes in the display and verify that all but the "Sensors" spoke displays the data along with the new text. Verify, too, that the text is always formatted in the center of the circle
* replace the `/iv/` section of the river gauge API endpoint with `/isnottherighturl` and refresh the app. Click through all the spokes again to verify that you see the fallback values along with the fallback headers & subscripts. Verify, too, that everything's centered and legible.