### PR TITLE
Add offline support

### DIFF
--- a/usgs-details.html
+++ b/usgs-details.html
@@ -142,7 +142,7 @@
         }
 
         // Function to capture results of USGS and populate values
-        function listenerFor(metric) {
+        function handleXHRResponse(metric) {
             return function() {
                 var value = metric.fallback[new Date().getMonth()];
                 var units = metric.units;
@@ -168,6 +168,17 @@
 
                 return renderData(value, units, metric, isFallback);
             };
+        }
+
+        // Handle XHR errors by using fallback data
+        function handleXHRError(metric) {
+            return function() {
+                var value = metric.fallback[new Date().getMonth()],
+                    units = metric.units,
+                    isFallback = true;
+
+                return renderData(value, units, metric, isFallback);
+            }
         }
 
         // Create header text for live and fallback values
@@ -198,12 +209,10 @@
 
             console.log('Fetching data from ' + url);
 
-            xhr.addEventListener('load', listenerFor(metric));
+            xhr.addEventListener('load', handleXHRResponse(metric));
+            xhr.addEventListener('error', handleXHRError(metric));
             xhr.open('GET', url);
             xhr.send();
-
-            // TODO Handle offline, DNS resolution, other XHR failures
-            // https://github.com/azavea/pwd-river-dispatches/issues/15
         }
 
         // Get metric from Query Parameter and fetch and populate values


### PR DESCRIPTION
## Overview

This PR adds offline support for the app by adding an `error` event listener to the XHR object. The listener function calls `renderData` with arguments set to display the fallback values.

Connects #15 

## Notes

Only the last commit here is for this PR. The others are from #19, but I branched off that one in order not to have to rewrite the `renderData` function.

## Testing
* get this branch, then run `server`
* turn off your wifi connection, then visit the app in the browser
* click through each of the spokes and verify that the fallback values load for each of them (except the sensor spoke, which doesn't show any data)
* turn the wifi back on and click through the spokes again to verify that you see real data from completed requests