### PR TITLE
Add assets/ dir to cipublish script

### DIFF
--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -16,7 +16,7 @@ if [ "${BASH_SOURCE}[0]}" ]; then
 
     git rev-parse HEAD > version.txt
     zip -r dist/pwd-river-dispatches-release.zip usgs-details.html version.txt \
-        images/ CHANGELOG.md media/ edge_includes/ Dispatches_v04t* -x *.zip
-
+        assets/ images/ CHANGELOG.md media/ edge_includes/ Dispatches_v04t* \
+        -x *.zip
     fi
 fi


### PR DESCRIPTION
## Overview

This PR adds the `assets/` dir to the cipublish script so that Jenkins will include the fonts and illustration from #27 in release builds.

Connects #28 
Connects #25 

## Testing

* get this branch, then run `cipublish`
* move that zip file to its own directory and unzip it
* serve the app and verify that you see the illustration on the "Sensors" spoke and that the new fonts and layout are visible on the other spokes

Once this is in I'll make another release so that Jenkins will have all the changes in the zip.