### PR TITLE
Bucket Turbidity Numbers

### DIFF
--- a/usgs-details.html
+++ b/usgs-details.html
@@ -43,7 +43,7 @@
          .container[name='sensor']{
             background-image: url("assets/Sensor_Illustration_opt1.png");
             background-repeat: no-repeat;
-            background-size: contain;   
+            background-size: contain;
             height: 400px;
             margin-left: 141px;
             margin-top: 150px;
@@ -65,7 +65,7 @@
             width: 100px;
             margin: 9px auto 15px;
         }
-        
+
         #value,
         #units {
             font-family: 'League Gothic', 'Gill Sans', 'Gill Sans MT', 'Myriad Pro', 'DejaVu Sans Condensed', Helvetica, Arial, sans-serif;
@@ -300,7 +300,7 @@
             var metric = METRICS[getQueryParameterByName('metric')];
             if (!metric) {
                 console.warn('Could not find metric for ' + metric);
-                
+
                 // Sensor lacks metrics, so giving its div.container a name of "sensor"
                 // in order to apply some specific styles.
                 var container = document.getElementsByClassName('container');

--- a/usgs-details.html
+++ b/usgs-details.html
@@ -159,9 +159,11 @@
                 code: '63680',
                 units: '',
                 transform: function(t) {
-                    // TODO Convert number to VERY_LOW to VERY_HIGH
-                    // https://github.com/azavea/pwd-river-dispatches/issues/16
-                    return t;
+                    if (t <=  10) { return VERY_LOW;  } else
+                    if (t <=  17) { return LOW;       } else
+                    if (t <=  40) { return MODERATE;  } else
+                    if (t <= 240) { return HIGH;      } else
+                                  { return VERY_HIGH; }
                 },
                 fallback: [
                     VERY_LOW, VERY_LOW, LOW, LOW, MODERATE, MODERATE, HIGH, VERY_HIGH, HIGH, HIGH, MODERATE, LOW


### PR DESCRIPTION
## Overview

Converts FNU numeric response from the API into text values that match labels used in the Turbidity section.

Connects #16 

### Demo

![image](https://user-images.githubusercontent.com/1430060/29041752-19b8b7da-7b82-11e7-864c-7a1b69511b2b.png)

## Testing Instructions

 * Check out this branch, run `server`
 * Go to [:9000/](http://localhost:9000/) and ensure the Turbidity page shows text
 * Inspect the browser console, ensure that the number you see being fetched from the API corresponds to the correct bucket as described in https://github.com/azavea/pwd-river-dispatches/issues/16#issuecomment-311962648
