### PR TITLE
Use fallback for no data values

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://editorconfig.org
+root = true
+
+[usgs-details.html]
+charset = utf-8
+indent_size = 4
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+ 

--- a/usgs-details.html
+++ b/usgs-details.html
@@ -206,9 +206,15 @@
                     var json = JSON.parse(this.responseText);
 
                     try {
+                        var noDataValue = json.value.timeSeries[0].variable.noDataValue;
                         var apiValue = json.value.timeSeries[0].values[0].value[0].value;
                         var apiUnits = json.value.timeSeries[0].variable.unit.unitCode;
                         console.log('From API: ' + apiValue + ' ' + apiUnits);
+                        console.log('No data value: ' + noDataValue);
+
+                        if (Number(apiValue) === Number(noDataValue)) {
+                            throw new Error('apiValue ' + apiValue + ' is noDataValue ' + noDataValue);
+                        }
 
                         value = metric.transform(apiValue);
                         isFallback = false;


### PR DESCRIPTION
## Overview

This PR fixes the quirk described in #35 whereby sensors whose value readings are the `noDataValue`s would report those as real values in the UI. To fix it we

- check whether the sensor's reading value is the attribute's reported `noDataValue`
- if it is, we throw an error inside the `try` -- which is immediately caught, causing the data retrieving functionality to fallback first to the backup sensor and then to the typical fallback value.

Connects #35 

## Notes

First commit here is just some project cleanup: an `.editorConfig` file applied only to `usgs-details.html`, which is the only place where our code lives.

## Testing

- get this branch, then set the project up according to the setup instructions
- visit the application in Chrome and open the js console
- check each of the spokes to ensure that you see either real or typical values
- for oxygen and pH the sensors are currently showing the `noData` values, check that they now show typical values and that you see a warning like `Error while parsing result: apiValue -999999 is noDataValue -999999` in the console.